### PR TITLE
Remove example_function and update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.swp
 *.zwc
 *.zwc.old
+zoxide.zsh

--- a/functions/example_function
+++ b/functions/example_function
@@ -1,4 +1,0 @@
-# this is an example function
-# running 'example_function' in a zsh session will execute the code below
-
-print "executed example function: ${ZIM_HOME}/modules/custom/functions/example_function!"


### PR DESCRIPTION
The example_function is not needed, it's just a placeholder from the template repository. Add zoxide.zsh to .gitignore since that's a cached file we don't want to track.
